### PR TITLE
Added a new test-case to ensure that foreign key validation on empty tables functions correctly.

### DIFF
--- a/src/main/scala/csvwcheck/Main.scala
+++ b/src/main/scala/csvwcheck/Main.scala
@@ -104,8 +104,8 @@ object Main extends App {
         })
         .recover(e => {
           println(Console.RED + "")
-          println("Unhandled Exception")
-          println(e)
+          logger.error("Unhandled Exception")
+          logger.error(e.toString)
           print(Console.RESET + "")
           sys.exit(1)
         })

--- a/src/main/scala/csvwcheck/Main.scala
+++ b/src/main/scala/csvwcheck/Main.scala
@@ -102,6 +102,13 @@ object Main extends App {
           println(Console.GREEN + "Valid CSV-W")
           print(Console.RESET + "")
         })
+        .recover(e => {
+          println(Console.RED + "")
+          println("Unhandled Exception")
+          println(e)
+          print(Console.RESET + "")
+          sys.exit(1)
+        })
       Await.ready(akkaStream.runWith(Sink.ignore), Duration.Inf)
       actorSystem.terminate()
     case _ =>

--- a/src/test/resources/csvwExamples/zerorowforeignkeys/cities.csv
+++ b/src/test/resources/csvwExamples/zerorowforeignkeys/cities.csv
@@ -1,0 +1,1 @@
+cityName, countryCode

--- a/src/test/resources/csvwExamples/zerorowforeignkeys/cities.csv-metadata.json
+++ b/src/test/resources/csvwExamples/zerorowforeignkeys/cities.csv-metadata.json
@@ -1,0 +1,44 @@
+{
+  "@context": "http://www.w3.org/ns/csvw",
+  "tables": [
+    {
+      "url": "cities.csv",
+      "tableSchema": {
+        "columns": [
+          {
+            "name": "cityName",
+            "titles": "cityName"
+          },
+          {
+            "name": "countryCode",
+            "titles": "countryCode"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "columnReference": "countryCode",
+            "reference": {
+              "resource": "countries.csv",
+              "columnReference": "countryCode"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "url": "countries.csv",
+      "tableSchema": {
+        "columns": [
+          {
+            "name": "countryCode",
+            "titles": "countryCode"
+          },
+          {
+            "name": "name",
+            "titles": "name"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/src/test/resources/csvwExamples/zerorowforeignkeys/countries.csv
+++ b/src/test/resources/csvwExamples/zerorowforeignkeys/countries.csv
@@ -1,0 +1,1 @@
+countryCode, name

--- a/src/test/scala/csvwcheck/TestUtils.scala
+++ b/src/test/scala/csvwcheck/TestUtils.scala
@@ -12,9 +12,16 @@ object TestUtils {
 
   def RunValidationInAkka(validator: Validator): WarningsAndErrors = {
     var warningsAndErrors = WarningsAndErrors()
+    var error: Option[Throwable] = None
+
     val akkaStream =
-      validator.validate().map(wAndE => warningsAndErrors = wAndE)
+      validator
+        .validate()
+        .map(wAndE => warningsAndErrors = wAndE)
+        .recover(err => error = Some(err))
     Await.ready(akkaStream.runWith(Sink.ignore), 10.hours)
+
+    error.foreach(e => throw e)
 
     warningsAndErrors
   }

--- a/src/test/scala/csvwcheck/bugs/ForeignKeys.scala
+++ b/src/test/scala/csvwcheck/bugs/ForeignKeys.scala
@@ -7,7 +7,7 @@ import org.scalatest.funsuite.AnyFunSuite
 
 class ForeignKeys extends AnyFunSuite {
 
-  test("A foreign key definition referencing a list column should return an error") {
+  test("A foreign key definition referencing a  list column should return an error") {
     // Code reference 7da26b34-efa5-11ef-8180-57883ec4256f
     val csvwInput = resourcesPath./("csvwExamples")./("foreign-key-with-separator.csv-metadata.json")
     val validator = new Validator(Some(csvwInput.path.toString))
@@ -19,5 +19,16 @@ class ForeignKeys extends AnyFunSuite {
 
     assert(error.`type` == "metadata")
     assert(error.content.contains("foreign key references list column"))
+  }
+
+
+  test("A foreign key reference should work even when the child table (and/or parent table) is empty.") {
+    // Code reference d662ed3e-113d-11f0-9ba8-237e5819328e
+    val csvwInput = resourcesPath./("csvwExamples")./("zerorowforeignkeys")./("cities.csv-metadata.json")
+    val validator = new Validator(Some(csvwInput.path.toString))
+    val warningsAndErrors = RunValidationInAkka(validator)
+
+    assert(warningsAndErrors.warnings.isEmpty)
+    assert(warningsAndErrors.errors.isEmpty)
   }
 }


### PR DESCRIPTION
I have also improved logging a small bit so that the end-user is aware of which CSV file more errors occurred in.

Further, I discovered that some errors weren't correctly being logged.

The result of validating a CSV-W where an unhandled error occurred was to return with a zero status code and output nothing useful to the logs:

```bash
$ csvw-check -s remote/Action.csv-metadata.json 
$ echo $?
0
$ csvw-check -s remote/Action.csv-metadata.json --log-level debug
[DEBUG] [04/04/2025 11:02:41.029] [main] [EventStream(akka://actor-system)] logger log1-Logging$DefaultLogger started
[DEBUG] [04/04/2025 11:02:41.029] [main] [EventStream(akka://actor-system)] Default Loggers started
[DEBUG] [04/04/2025 11:02:41.061] [main] [akka.serialization.Serialization(akka://actor-system)] Replacing JavaSerializer with DisabledJavaSerializer, due to `akka.actor.allow-java-serialization = off`.
[INFO] [04/04/2025 11:02:41.780] [main] [CoordinatedShutdown(akka://actor-system)] Running CoordinatedShutdown with reason [ActorSystemTerminateReason]
[DEBUG] [04/04/2025 11:02:41.780] [main] [CoordinatedShutdown(akka://actor-system)] Performing phase [before-service-unbind] with [0] tasks
[DEBUG] [04/04/2025 11:02:41.782] [actor-system-akka.actor.internal-dispatcher-4] [CoordinatedShutdown(akka://actor-system)] Performing phase [service-unbind] with [0] tasks
[DEBUG] [04/04/2025 11:02:41.782] [actor-system-akka.actor.internal-dispatcher-4] [CoordinatedShutdown(akka://actor-system)] Performing phase [service-requests-done] with [0] tasks
[DEBUG] [04/04/2025 11:02:41.782] [actor-system-akka.actor.internal-dispatcher-4] [CoordinatedShutdown(akka://actor-system)] Performing phase [service-stop] with [0] tasks
[DEBUG] [04/04/2025 11:02:41.782] [actor-system-akka.actor.internal-dispatcher-4] [CoordinatedShutdown(akka://actor-system)] Performing phase [before-cluster-shutdown] with [0] tasks
[DEBUG] [04/04/2025 11:02:41.782] [actor-system-akka.actor.internal-dispatcher-4] [CoordinatedShutdown(akka://actor-system)] Performing phase [cluster-sharding-shutdown-region] with [0] tasks
[DEBUG] [04/04/2025 11:02:41.782] [actor-system-akka.actor.internal-dispatcher-4] [CoordinatedShutdown(akka://actor-system)] Performing phase [cluster-leave] with [0] tasks
[DEBUG] [04/04/2025 11:02:41.782] [actor-system-akka.actor.internal-dispatcher-4] [CoordinatedShutdown(akka://actor-system)] Performing phase [cluster-exiting] with [0] tasks
[DEBUG] [04/04/2025 11:02:41.782] [actor-system-akka.actor.internal-dispatcher-4] [CoordinatedShutdown(akka://actor-system)] Performing phase [cluster-exiting-done] with [0] tasks
[DEBUG] [04/04/2025 11:02:41.782] [actor-system-akka.actor.internal-dispatcher-4] [CoordinatedShutdown(akka://actor-system)] Performing phase [cluster-shutdown] with [0] tasks
[DEBUG] [04/04/2025 11:02:41.782] [actor-system-akka.actor.internal-dispatcher-4] [CoordinatedShutdown(akka://actor-system)] Performing phase [before-actor-system-terminate] with [0] tasks
[DEBUG] [04/04/2025 11:02:41.782] [actor-system-akka.actor.internal-dispatcher-4] [CoordinatedShutdown(akka://actor-system)] Performing phase [actor-system-terminate] with [1] tasks.
[DEBUG] [04/04/2025 11:02:41.783] [actor-system-akka.actor.internal-dispatcher-4] [CoordinatedShutdown(akka://actor-system)] Performing task [terminate-system] in CoordinatedShutdown phase [actor-system-terminate]
[DEBUG] [04/04/2025 11:02:41.787] [actor-system-akka.actor.internal-dispatcher-3] [EventStream] shutting down: StandardOutLogger
```